### PR TITLE
build: add spec.strategy.resources to all DeploymentConfig objects

### DIFF
--- a/helm-chart/Chart.yaml
+++ b/helm-chart/Chart.yaml
@@ -11,6 +11,6 @@ description: |
    and High Performance Computing (HPC) platforms. See https://st4sd.github.io/overview for more information.
 type: application
 
-version: "0.10.2"
+version: "0.10.3"
 
-appVersion: "2.0.0-alpha11"
+appVersion: "2.0.0-alpha12"

--- a/helm-chart/templates/dc-authentication.yaml
+++ b/helm-chart/templates/dc-authentication.yaml
@@ -14,7 +14,7 @@ spec:
     st4sd.ibm.com/component: authentication
   strategy:
     activeDeadlineSeconds: 21600
-    resources: {}
+    resources: {{ toYaml .Values.resourcesDeploymentConfigStrategy.authentication | nindent 6 }}
     rollingParams:
       intervalSeconds: 1
       maxSurge: 25%

--- a/helm-chart/templates/dc-datastore-instance.yaml
+++ b/helm-chart/templates/dc-datastore-instance.yaml
@@ -13,7 +13,7 @@ spec:
     app: st4sd-datastore-cloud-instance
   strategy:
     activeDeadlineSeconds: 21600
-    resources: {}
+    resources: {{ toYaml .Values.resourcesDeploymentConfigStrategy.datastoreInstance | nindent 6 }}
     rollingParams:
       intervalSeconds: 1
       maxSurge: 25%

--- a/helm-chart/templates/dc-datastore-mongodb.yaml
+++ b/helm-chart/templates/dc-datastore-mongodb.yaml
@@ -14,7 +14,7 @@ spec:
     name: st4sd-datastore-mongodb
   strategy:
     activeDeadlineSeconds: 21600
-    resources: {}
+    resources: {{ toYaml .Values.resourcesDeploymentConfigStrategy.datastoreMongoDB | nindent 6 }}
     recreateParams: {}
     type: Recreate
   template:

--- a/helm-chart/templates/dc-datastore-nexus.yaml
+++ b/helm-chart/templates/dc-datastore-nexus.yaml
@@ -13,7 +13,7 @@ spec:
     app: st4sd-datastore-nexus
   strategy:
     activeDeadlineSeconds: 21600
-    resources: {}
+    resources: {{ toYaml .Values.resourcesDeploymentConfigStrategy.datastoreNexus | nindent 6 }}
     rollingParams:
       intervalSeconds: 1
       maxSurge: 25%

--- a/helm-chart/templates/dc-registry-backend.yaml
+++ b/helm-chart/templates/dc-registry-backend.yaml
@@ -11,6 +11,11 @@ spec:
   selector:
     app: st4sd-registry-backend
     st4sd.ibm.com/component: registry-backend
+  strategy:
+    activeDeadlineSeconds: 21600
+    resources: {{ toYaml .Values.resourcesDeploymentConfigStrategy.registryBackend | nindent 6 }}
+    recreateParams: { }
+    type: Recreate
   template:
     metadata:
       labels:

--- a/helm-chart/templates/dc-registry-ui.yaml
+++ b/helm-chart/templates/dc-registry-ui.yaml
@@ -11,6 +11,11 @@ spec:
   selector:
     app: st4sd-registry-ui
     st4sd.ibm.com/component: registry-ui
+  strategy:
+    activeDeadlineSeconds: 21600
+    resources: {{ toYaml .Values.resourcesDeploymentConfigStrategy.registryUI | nindent 6 }}
+    recreateParams: { }
+    type: Recreate
   template:
     metadata:
       labels:

--- a/helm-chart/templates/dc-runtime-k8s.yaml
+++ b/helm-chart/templates/dc-runtime-k8s.yaml
@@ -14,7 +14,7 @@ spec:
     st4sd.ibm.com/component: workflow-operator
   strategy:
     activeDeadlineSeconds: 21600
-    resources: {}
+    resources: {{ toYaml .Values.resourcesDeploymentConfigStrategy.runtimeK8s | nindent 6 }}
     rollingParams:
       intervalSeconds: 1
       maxSurge: 25%

--- a/helm-chart/templates/dc-runtime-service.yaml
+++ b/helm-chart/templates/dc-runtime-service.yaml
@@ -11,6 +11,16 @@ spec:
   selector:
     app: st4sd-runtime-service
     st4sd.ibm.com/component: runtime-service
+  strategy:
+    activeDeadlineSeconds: 21600
+    resources: {{ toYaml .Values.resourcesDeploymentConfigStrategy.runtimeService | nindent 6 }}
+    rollingParams:
+      intervalSeconds: 1
+      maxSurge: 25%
+      maxUnavailable: 25%
+      timeoutSeconds: 600
+      updatePeriodSeconds: 1
+    type: Rolling
   template:
     metadata:
       labels:

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -159,6 +159,8 @@ namespaceContainersFsGroupCommon: 5000
 namespaceContainersFsGroupRangeMin: 5000
 namespaceContainersFsGroupRangeMax: 25000
 
+
+# The resource requests/limits of the microservices
 resources:
   datastoreMongoDB:
     limits:
@@ -201,6 +203,42 @@ resources:
       cpu: 500m
       memory: 256Mi
   registryUI:
+    limits:
+      cpu: 250m
+      memory: 256Mi
+
+# The resources of the deployment pods that rollout the microservice pods - these are pods that OpenShift
+# creates for handling a DeploymentConfig rollout.
+resourcesDeploymentConfigStrategy:
+  authentication:
+    limits:
+      cpu: 250m
+      memory: 256Mi
+  datastoreInstance:
+    limits:
+      cpu: 250m
+      memory: 256Mi
+  datastoreMongoDB:
+    limits:
+      cpu: 250m
+      memory: 256Mi
+  datastoreNexus:
+    limits:
+      cpu: 250m
+      memory: 256Mi
+  registryBackend:
+    limits:
+      cpu: 250m
+      memory: 256Mi
+  registryUI:
+    limits:
+      cpu: 250m
+      memory: 256Mi
+  runtimeK8s:
+    limits:
+      cpu: 250m
+      memory: 256Mi
+  runtimeService:
     limits:
       cpu: 250m
       memory: 256Mi


### PR DESCRIPTION
## Context

This enables deploying ST4SD in namespaces which contain ResourceQuota objects with "hard rules" for resources (e.g. cpu, ram, etc). The ResourceQuota object rejects any pod without resource limits. The spec.strategy.resources field causes the DeploymentConfig object to spawn pods with a `spec.resource` field.

Fixes #4


## Change list

Write a few bullet points of the changes contained in this PR:

-st4sd-deployment uses DeploymentConfig objects which come with a configurable spec.strategy.resources field.
- The default value is {"limits": {"cpu": "250m", "256Mi"}}
- The field is configurable via the helm chart option `resources.resourcesDeploymentConfigStrategy.{name of deployment config object}`

## Checklist

Ensure your PR meets the following requirements:

- [x] This PR is associated to one (or more) issues that are open
- [x] I have signed off my commits (using `git commit -s`)
- [x] I agree with the ST4SD Code of Conduct
